### PR TITLE
Added RootExtensions field to vrm struct

### DIFF
--- a/bevy_vrm/src/lib.rs
+++ b/bevy_vrm/src/lib.rs
@@ -1,8 +1,8 @@
 use bevy::{gltf::GltfMesh, prelude::*, utils::HashMap};
 use bevy_shader_mtoon::{MtoonMaterial, MtoonPlugin};
-use loader::VrmLoader;
+use loader::{RootExtensions, VrmLoader};
 
-mod extensions;
+pub mod extensions;
 pub mod loader;
 
 pub mod mtoon {
@@ -37,6 +37,8 @@ pub struct Vrm {
     pub mtoon_materials: HashMap<usize, Handle<MtoonMaterial>>,
     /// Meshes that use MToon
     pub mtoon_markers: Vec<MtoonMarker>,
+    /// GLTF vrm extension info.
+    pub extensions: RootExtensions,
 }
 
 #[derive(Bundle, Default)]

--- a/bevy_vrm/src/loader/mod.rs
+++ b/bevy_vrm/src/loader/mod.rs
@@ -99,20 +99,20 @@ async fn load_vrm<'a, 'b>(
     load_context: &'a mut LoadContext<'b>,
 ) -> Result<Vrm, VrmError> {
     let (gltf_file, _) = goth_gltf::Gltf::from_bytes(bytes)?;
-
     let mut vrm = Vrm {
         gltf,
-        mtoon_materials: HashMap::default(),
-        mtoon_markers: Vec::default(),
+        mtoon_materials: default(),
+        mtoon_markers: default(),
+        extensions: default(),
     };
 
-    if let Ok(_) = vrm0::load_gltf(&mut vrm, &gltf_file, load_context) {
+    if let Ok(()) = vrm0::load_gltf(&mut vrm, &gltf_file, load_context) {
         info!("VRM 0.0 loaded");
-    } else if let Ok(_) = vrm::load_gltf(&mut vrm, &gltf_file, load_context) {
+    } else if let Ok(()) = vrm::load_gltf(&mut vrm, &gltf_file, load_context) {
         info!("VRM 1.0 loaded");
     } else {
         error!("VRM extension not found");
-    }
+    };
 
     Ok(vrm)
 }

--- a/bevy_vrm/src/loader/vrm.rs
+++ b/bevy_vrm/src/loader/vrm.rs
@@ -2,15 +2,17 @@ use bevy::asset::LoadContext;
 
 use crate::Vrm;
 
-pub fn load_gltf(
-    _vrm: &mut Vrm,
-    gltf: &goth_gltf::Gltf<super::Extensions>,
+pub(crate) fn load_gltf(
+    vrm: &mut Vrm,
+    goth_gltf: &goth_gltf::Gltf<super::Extensions>,
     _load_context: &mut LoadContext,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _vrmc_vrm = match &gltf.extensions.vrmc_vrm {
+    let _vrmc_vrm = match &goth_gltf.extensions.vrmc_vrm {
         Some(vrmc_vrm) => vrmc_vrm,
         None => return Err("VRMC_vrm not found".into()),
     };
+
+    vrm.extensions = goth_gltf.extensions.clone();
 
     Ok(())
 }

--- a/bevy_vrm/src/loader/vrm0.rs
+++ b/bevy_vrm/src/loader/vrm0.rs
@@ -8,12 +8,12 @@ use crate::{extensions::vrm0::MaterialProperty, MtoonMarker, Vrm};
 
 const MTOON_KEY: &str = "VRM/MToon";
 
-pub fn load_gltf(
+pub(crate) fn load_gltf(
     vrm: &mut Vrm,
-    gltf: &goth_gltf::Gltf<super::Extensions>,
+    goth_gltf: &goth_gltf::Gltf<super::Extensions>,
     load_context: &mut LoadContext,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let vrm0 = match &gltf.extensions.vrm0 {
+    let vrm0 = match &goth_gltf.extensions.vrm0 {
         Some(vrm0) => vrm0,
         None => return Err("VRM0 not found".into()),
     };
@@ -39,7 +39,8 @@ pub fn load_gltf(
     }
 
     // Create MtoonMarkers
-    gltf.meshes
+    goth_gltf
+        .meshes
         .iter()
         .enumerate()
         .for_each(|(mesh_index, mesh)| {
@@ -71,6 +72,8 @@ pub fn load_gltf(
                     });
                 });
         });
+
+    vrm.extensions = goth_gltf.extensions.clone();
 
     Ok(())
 }


### PR DESCRIPTION
Exposing the deserialized vrm extension information is needed for making use of the `Humanoid` struct.