### PR TITLE
Fix model loading and springbone recognition of new bevy version

### DIFF
--- a/crates/bevy_vrm/src/auto_scene.rs
+++ b/crates/bevy_vrm/src/auto_scene.rs
@@ -37,9 +37,8 @@ pub fn set_vrm_scene(
             continue;
         }
 
-        commands.entity(entity).insert((
-            VrmScene(vrm_scene.clone()),
-            SceneRoot(vrm_scene.clone()),
-        ));
+        commands
+            .entity(entity)
+            .insert((VrmScene(vrm_scene.clone()), SceneRoot(vrm_scene.clone())));
     }
 }

--- a/crates/bevy_vrm/src/auto_scene.rs
+++ b/crates/bevy_vrm/src/auto_scene.rs
@@ -37,6 +37,9 @@ pub fn set_vrm_scene(
             continue;
         }
 
-        commands.entity(entity).insert(VrmScene(vrm_scene.clone()));
+        commands.entity(entity).insert((
+            VrmScene(vrm_scene.clone()),
+            SceneRoot(vrm_scene.clone()),
+        ));
     }
 }

--- a/crates/bevy_vrm/src/extensions/mod.rs
+++ b/crates/bevy_vrm/src/extensions/mod.rs
@@ -153,7 +153,7 @@ impl BevyExtensionImport<GltfDocument> for VrmExtensions {
                         .gltf
                         .named_nodes
                         .iter()
-                        .find_map(|(name, n)| (n == node_handle).then(|| name.clone()))?;
+                        .find_map(|(name, node)| (node == node_handle).then(|| name.clone()))?;
                     let (entity, _) = names.iter().find(|(_, name)| name.as_str() == node_name)?;
                     Some((*entity, node_name))
                 })

--- a/crates/bevy_vrm/src/extensions/mod.rs
+++ b/crates/bevy_vrm/src/extensions/mod.rs
@@ -149,11 +149,14 @@ impl BevyExtensionImport<GltfDocument> for VrmExtensions {
                 .into_iter()
                 .filter_map(|node| {
                     let node_handle = context.gltf.node_handles.get(&node)?;
-                    let node_name = context
-                        .gltf
-                        .named_nodes
-                        .iter()
-                        .find_map(|(name, node)| (node == node_handle).then(|| name.clone()))?;
+                    let node_name =
+                        context
+                            .gltf
+                            .named_nodes
+                            .iter()
+                            .find_map(|(name, gltf_node)| {
+                                (gltf_node == node_handle).then(|| name.clone())
+                            })?;
                     let (entity, _) = names.iter().find(|(_, name)| name.as_str() == node_name)?;
                     Some((*entity, node_name))
                 })

--- a/crates/bevy_vrm/src/lib.rs
+++ b/crates/bevy_vrm/src/lib.rs
@@ -63,4 +63,5 @@ pub struct VrmBundle {
     pub auto_scene: AutoScene,
     pub scene: VrmScene,
     pub vrm: VrmInstance,
+    pub scene_root: SceneRoot,
 }

--- a/crates/bevy_vrm/src/loader.rs
+++ b/crates/bevy_vrm/src/loader.rs
@@ -1,12 +1,15 @@
 use std::fmt::Debug;
 
 use bevy::{
-    asset::{AssetLoader, LoadContext, io::{Reader, VecReader}},
+    asset::{
+        AssetLoader, LoadContext,
+        io::{Reader, VecReader},
+    },
     prelude::*,
 };
 use bevy_gltf_kun::import::gltf::{
     GltfKun,
-    loader::{GltfError, GltfLoader, GlbLoader},
+    loader::{GlbLoader, GltfError, GltfLoader},
 };
 use thiserror::Error;
 
@@ -43,16 +46,23 @@ impl AssetLoader for VrmLoader {
     {
         Box::pin(async move {
             let mut bytes = Vec::new();
-            reader.read_to_end(&mut bytes).await.map_err(|e| VrmError::Gltf(GltfError::Io(e)))?;
+            reader
+                .read_to_end(&mut bytes)
+                .await
+                .map_err(|e| VrmError::Gltf(GltfError::Io(e)))?;
 
             let is_glb = bytes.len() >= 4 && &bytes[0..4] == b"glTF";
 
             let gltf = if is_glb {
                 let mut vec_reader = VecReader::new(bytes);
-                self.glb_loader.load(&mut vec_reader, settings, load_context).await?
+                self.glb_loader
+                    .load(&mut vec_reader, settings, load_context)
+                    .await?
             } else {
                 let mut vec_reader = VecReader::new(bytes);
-                self.gltf_loader.load(&mut vec_reader, settings, load_context).await?
+                self.gltf_loader
+                    .load(&mut vec_reader, settings, load_context)
+                    .await?
             };
 
             Ok(Vrm { gltf })

--- a/crates/bevy_vrm/src/loader.rs
+++ b/crates/bevy_vrm/src/loader.rs
@@ -1,12 +1,12 @@
 use std::fmt::Debug;
 
 use bevy::{
-    asset::{AssetLoader, LoadContext, io::Reader},
+    asset::{AssetLoader, LoadContext, io::{Reader, VecReader}},
     prelude::*,
 };
 use bevy_gltf_kun::import::gltf::{
     GltfKun,
-    loader::{GltfError, GltfLoader},
+    loader::{GltfError, GltfLoader, GlbLoader},
 };
 use thiserror::Error;
 
@@ -18,7 +18,10 @@ pub struct Vrm {
 }
 
 #[derive(Default)]
-pub struct VrmLoader(pub GltfLoader<VrmExtensions>);
+pub struct VrmLoader {
+    pub gltf_loader: GltfLoader<VrmExtensions>,
+    pub glb_loader: GlbLoader<VrmExtensions>,
+}
 
 #[derive(Debug, Error)]
 pub enum VrmError {
@@ -39,7 +42,19 @@ impl AssetLoader for VrmLoader {
     ) -> impl bevy::tasks::ConditionalSendFuture<Output = std::result::Result<Self::Asset, Self::Error>>
     {
         Box::pin(async move {
-            let gltf = self.0.load(reader, settings, load_context).await?;
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await.map_err(|e| VrmError::Gltf(GltfError::Io(e)))?;
+
+            let is_glb = bytes.len() >= 4 && &bytes[0..4] == b"glTF";
+
+            let gltf = if is_glb {
+                let mut vec_reader = VecReader::new(bytes);
+                self.glb_loader.load(&mut vec_reader, settings, load_context).await?
+            } else {
+                let mut vec_reader = VecReader::new(bytes);
+                self.gltf_loader.load(&mut vec_reader, settings, load_context).await?
+            };
+
             Ok(Vrm { gltf })
         })
     }

--- a/crates/vrm_viewer/src/lib.rs
+++ b/crates/vrm_viewer/src/lib.rs
@@ -145,11 +145,13 @@ fn load_model(
     let mut transform = Transform::default();
     transform.rotate_y(PI);
 
+    let handle = asset_server.load(settings.model.clone());
+
     commands.spawn((
         transform,
         VrmBundle {
             scene: VrmScene::default(),
-            vrm: VrmInstance(asset_server.load(settings.model.clone())),
+            vrm: VrmInstance(handle),
             ..default()
         },
     ));

--- a/crates/vrm_viewer/src/lib.rs
+++ b/crates/vrm_viewer/src/lib.rs
@@ -145,13 +145,11 @@ fn load_model(
     let mut transform = Transform::default();
     transform.rotate_y(PI);
 
-    let handle = asset_server.load(settings.model.clone());
-
     commands.spawn((
         transform,
         VrmBundle {
             scene: VrmScene::default(),
-            vrm: VrmInstance(handle),
+            vrm: VrmInstance(asset_server.load(settings.model.clone())),
             ..default()
         },
     ));


### PR DESCRIPTION
The model did not load correctly, so I added GLB support and a SceneRoot.

For the SpringBone fix. When VRM models were reloaded, the Bevy entities would be destroyed and recreated with new Entity IDs. However, the spring bone system stored direct references to these entities, which then became invalid.

So remapping them to the new Entity ID fixes it.

Let me know what you think